### PR TITLE
增加关卡手动选择 & 萨卡兹肉鸽

### DIFF
--- a/src-tauri/src/events/config.rs
+++ b/src-tauri/src/events/config.rs
@@ -157,3 +157,21 @@ pub fn get_item_index() -> payload::Payload<serde_json::Value> {
     let data =serde_json::from_str(&item_index_str).unwrap_or_else(|err| panic!("读取{}失败:{}",maa_cli::data_dir().join(&"resource").join(&"item_index.json").to_str().unwrap(), err.to_string()));
     payload::new(consts::SUCCESS, "success".to_string(), data)
 }
+
+#[tauri::command]
+pub fn get_fight_stages() -> payload::Payload<serde_json::Value> {
+    let fight_stages_str =
+            fs::read_to_string(maa_cli::data_dir().join(&"resource").join(&"stages.json"))
+                .unwrap_or_else(|err| panic!("读取{}失败:{}",maa_cli::data_dir().join(&"resource").join(&"stages.json").to_str().unwrap(), err.to_string()));
+    let data =serde_json::from_str(&fight_stages_str).unwrap_or_else(|err| panic!("读取{}失败:{}",maa_cli::data_dir().join(&"resource").join(&"stages").to_str().unwrap(), err.to_string()));
+    payload::new(consts::SUCCESS, "success".to_string(), data)
+}
+
+#[tauri::command]
+pub fn get_current_sidestory() -> payload::Payload<serde_json::Value> {
+    let sidestory_stages_str =
+            fs::read_to_string(maa_cli::data_dir().join(&"MaaResource").join(&"cache").join(&"resource").join(&"tasks.json"))
+                .unwrap_or_else(|err| panic!("读取{}失败:{}",maa_cli::data_dir().join(&"MaaResource").join(&"cache").join(&"resource").join(&"tasks.json").to_str().unwrap(), err.to_string()));
+    let data =serde_json::from_str(&sidestory_stages_str).unwrap_or_else(|err| panic!("读取{}失败:{}",maa_cli::data_dir().join(&"MaaResource").join(&"cache").join(&"resource").join(&"tasks.json").to_str().unwrap(), err.to_string()));
+    payload::new(consts::SUCCESS, "success".to_string(), data)
+}

--- a/src-tauri/src/events/mod.rs
+++ b/src-tauri/src/events/mod.rs
@@ -5,7 +5,7 @@ mod payload;
 mod run;
 mod update;
 pub use config::{
-    delete_user_config, get_cli_config, get_item_index, get_user_configs, save_cli_config,
+    delete_user_config, get_cli_config, get_item_index, get_fight_stages, get_current_sidestory, get_user_configs, save_cli_config,
     save_core_config, save_task_config,
 };
 pub use init::init_process;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -16,8 +16,8 @@ use tauri::{
 };
 
 use events::{
-    copilot, delete_user_config, get_cli_config, get_item_index, get_user_configs,
-    ignore_maa_cli_update, init_process, maa_cli_update_process, one_key, save_cli_config,
+    copilot, delete_user_config, get_cli_config, get_item_index, get_fight_stages, get_current_sidestory, 
+    get_user_configs, ignore_maa_cli_update, init_process, maa_cli_update_process, one_key, save_cli_config,
     save_core_config, save_task_config, stop,
 };
 
@@ -67,6 +67,8 @@ fn main() {
             ignore_maa_cli_update,
             maa_cli_update_process,
             get_item_index,
+            get_fight_stages,
+            get_current_sidestory,
             copilot
         ])
         .system_tray(tray)

--- a/src/apis/FightStages.ts
+++ b/src/apis/FightStages.ts
@@ -1,0 +1,105 @@
+import { invoke } from '@tauri-apps/api/tauri';
+
+interface StageItem {
+    value: string;
+    label: string;
+}
+
+interface StageData {
+    stageId: string;
+    code: string;
+}
+
+interface Payload {
+    code: number;
+    msg: string;
+    data: StageData[];
+}
+
+// 标准 / 磨难
+const StageExtraSuffix = {
+    NORMAL: '-NORMAL',
+    TOUGH: '-HARD',
+}
+
+const currentStages: StageItem[] = [
+    { label: '当前关卡/上次作战', value: '' },
+]
+
+const appendSuffixAndCreateItems = (stage: any, suffix: string) => {
+    const suffixLabel = suffix === StageExtraSuffix.NORMAL ? ' (标准)' : ' (磨难)';
+    return {
+        value: stage.code + suffix,
+        label: stage.code + suffixLabel
+    };
+};
+
+const basicSupportStages: StageItem[] = [
+    { label: '1-7', value: '1-7' },
+    { label: '剿灭', value: 'Annihilation' },
+    { label: '龙门币-6/5', value: 'CE-6' },
+    { label: '经验-6/5', value: 'LS-6' },
+    { label: '红票-5', value: 'AP-5' },
+    { label: '技能-5', value: 'CA-5' },
+    { label: '重装/医疗-小', value: 'PR-A-1' },
+    { label: '重装/医疗-大', value: 'PR-A-2' },
+    { label: '狙击/术士-小', value: 'PR-B-1' },
+    { label: '狙击/术士-大', value: 'PR-B-2' },
+    { label: '辅助/先锋-小', value: 'PR-C-1' },
+    { label: '辅助/先锋-大', value: 'PR-C-2' },
+    { label: '特种/近卫-小', value: 'PR-D-1' },
+    { label: '特种/近卫-大', value: 'PR-D-2' },
+  ]
+
+function filterSideStoryStages(sideStoryData: Record<string, any>): StageItem[] {
+    const stageItems: StageItem[] = [];
+
+    for (const key of Object.keys(sideStoryData)) {
+        // 只取出有效的关卡名称
+        const parts = key.split('-');
+        if (parts.length > 1 && /^\d+$/.test(parts[1])) {
+            stageItems.push({
+                value: key,
+                label: key
+            });
+        }
+    }
+
+    return stageItems;
+}
+
+const GetFightStages = async (): Promise<StageItem[]> => {
+    try {
+        const result = await invoke<Payload>('get_fight_stages');
+        const sideStoryData = await invoke<Payload>('get_current_sidestory');
+        
+        const filteredStages = result.data
+            .filter(stage => stage.stageId.includes('main') || stage.stageId.includes('sub'))
+            .flatMap(stage => {
+                // 只要关卡号开头为9（如 9-1, 9-2 等）
+                if (stage.code.startsWith('9-')) {
+                    return [appendSuffixAndCreateItems(stage, StageExtraSuffix.NORMAL)];
+                }
+                // 处理关卡号开头为10或更高的情况（如 10-1, 11-1, 12-1 等）
+                else if (/^1[0-9]-/.test(stage.code)) {
+                    return [
+                        appendSuffixAndCreateItems(stage, StageExtraSuffix.NORMAL),
+                        appendSuffixAndCreateItems(stage, StageExtraSuffix.TOUGH)
+                    ];
+                }
+                return [{ value: stage.code, label: stage.code }];
+            });
+
+        const filteredSideStoryStages = filterSideStoryStages(sideStoryData.data);
+
+        // 合并全部可选关卡
+        return [...currentStages, ...filteredSideStoryStages,...basicSupportStages, ...filteredStages];
+    } catch (error) {
+        console.error('Failed to retrieve fight stages:', error);
+        return [];
+    }
+}
+
+export type { StageItem };
+
+export default GetFightStages;

--- a/src/components/OneKey/FightSetting.vue
+++ b/src/components/OneKey/FightSetting.vue
@@ -91,14 +91,18 @@
       "
     >
       <el-form-item label="关卡">
-        <el-tooltip
-          class="box-item"
-          effect="dark"
-          content="不填刷上次关卡，可在关卡结尾输入Normal/Hard表示需要切换标准与磨难难度，剿灭作战，必须输入Annihilation"
-          placement="top"
+        <el-select
+          v-model="params.stage"
+          :disabled="userConfig!.status == 1 && params.enable"
+          :loading="StageLoading"
         >
-          <el-input v-model="params.stage" :disabled="userConfig!.status == 1 && params.enable" />
-        </el-tooltip>
+          <el-option
+            v-for="stage in stage_options"
+            :key="stage.value"
+            :label="stage.label"
+            :value="stage.value"
+          />
+        </el-select>
       </el-form-item>
       <el-form-item label="指定次数">
         <el-input-number
@@ -129,6 +133,8 @@ import { type FightTaskParams } from '@/stores/tasks/Fight'
 import { onMounted, ref } from 'vue'
 import GetFightItems from '@/apis/ItemIndex'
 import { type FightItem } from '@/apis/ItemIndex'
+import GetFightStages from '@/apis/FightStages'
+import { type StageItem } from '@/apis/FightStages'
 const userConfigStore = UserConfigStore()
 const dialogVisible = ref(userConfigStore.GetSettingDialogObj())
 const params = ref<FightTaskParams>(userConfigStore.GetTaskParams('Fight') as FightTaskParams)
@@ -168,7 +174,19 @@ const drops_set = () => {
   }
 }
 
+// Reactive data for stages
+const stage_options = ref<StageItem[]>([]);
+const StageLoading = ref(false);
+
+// Fetch stages data when needed
+const fetchStages = async () => {
+  StageLoading.value = true;
+  stage_options.value = await GetFightStages();
+  StageLoading.value = false;
+};
+
 onMounted(() => {
+  fetchStages();
   if (params.value.drops) {
     drops_value.value = Object.keys(params.value.drops)[0]
   }

--- a/src/components/OneKey/RoguelikeSetting.vue
+++ b/src/components/OneKey/RoguelikeSetting.vue
@@ -23,6 +23,7 @@
               <el-option label="傀影与猩红血钻" value="Phantom" default />
               <el-option label="水月与深蓝之树" value="Mizuki" />
               <el-option label="探索者的银凇止境" value="Sami" />
+              <el-option label="萨卡兹的无终奇语" value="Sarkaz" />
             </el-select>
           </el-form-item>
           <el-form-item label="开始探索次数">
@@ -40,7 +41,7 @@
               @change="modeChange"
               :disabled="userConfig!.status == 1 && params.enable"
             >
-              <el-option label="刷蜡烛" :value="0" default />
+              <el-option label="刷蜡烛/通关" :value="0" default />
               <el-option label="刷源石锭" :value="1" />
               <el-option label="刷开局" :value="4" />
               <el-option label="刷坍缩范式" :value="5" />


### PR DESCRIPTION
首先感谢一下您的开发～ 苦于Linux下没有好用的MAA GUI好久了

今天在MAA那边讨论区看到后就赶紧下来了试了试，只能说占用低又流畅，非常之好用 XD
然后我看到TODO列表里还有些未完成，就参照之前用的[MaaX](https://github.com/MaaAssistantArknights/MaaX) 那边的格式稍微修改了下，加上去了刷理智时候关卡可以手动选择，简单测试了一下应该是可以的。另外顺手把萨卡兹肉鸽也加上去了。

我对前端技术栈也不是很熟，代码比较粗糙，烦请不吝斧正。